### PR TITLE
Add svg spritsheet support and Icon component

### DIFF
--- a/components/icon/Component.php
+++ b/components/icon/Component.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Icon extends Component
+{
+    /**
+     * The name of the icon file without extension
+     */
+    public string $icon;
+
+    /**
+     * The name of the spritesheet as defined in `vite.config.js`
+     */
+    public ?string $sheet;
+
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(string $icon, ?string $sheet = 'default')
+    {
+        $this->icon = $icon;
+        $this->sheet = $sheet;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.icon');
+    }
+}

--- a/components/icon/style.scss
+++ b/components/icon/style.scss
@@ -1,0 +1,4 @@
+.icon {
+    width: 100%;
+    height: 100%;
+}

--- a/components/icon/view.blade.php
+++ b/components/icon/view.blade.php
@@ -1,0 +1,3 @@
+<svg class="icon">
+    <use xlink:href="{{ asset('build/assets/'.$sheet.'.svg').'?'.filemtime(public_path('build/assets/'.$sheet.'.svg')).'#sprite-'.$icon }}"></use>
+</svg>

--- a/src/Components/Publishers/Icon.php
+++ b/src/Components/Publishers/Icon.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Whitecube\LaravelPreset\Components\Publishers;
+
+use Whitecube\LaravelPreset\Components\File;
+use Whitecube\LaravelPreset\Components\FilesCollection;
+use Whitecube\LaravelPreset\Components\PublisherInterface;
+
+class Icon implements PublisherInterface
+{
+    /**
+     * Get the component's displayable name.
+     */
+    public function label(): string
+    {
+        return 'Icon';
+    }
+
+    /**
+     * Let the publisher prompt for eventual extra input
+     * and return a collection of publishable files.
+     */
+    public function handle(): FilesCollection
+    {
+        $style = File::makeFromStub(
+            stub: 'components/icon/style.scss',
+            destination: resource_path('sass/parts/_icon.scss'),
+        );
+
+        $view = File::makeFromStub(
+            stub: 'components/icon/view.blade.php',
+            destination: resource_path('views/components/icon.blade.php'),
+        );
+
+        $component = File::makeFromStub(
+            stub: 'components/icon/Component.php',
+            destination: base_path('app/View/Components/Icon.php'),
+        );
+
+        return FilesCollection::make([
+            $style,
+            $view,
+            $component,
+        ]);
+    }
+
+    /**
+     * Get the component's usage instructions
+     */
+    public function instructions(): ?string
+    {
+        return "1. Add `@import 'parts/icons';` to `resources/sass/app.scss`\r\n2. Use the blade component: `<x-icon icon=\"arrow\" sheet=\"default\"/>`";
+    }
+}

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -54,6 +54,8 @@ class Preset extends LaravelPreset
                 'husky' => '^9.0.11',
                 'lint-staged' => '^15.2.7',
                 'prettier' => '^3.3.2',
+                "@spiriit/vite-plugin-svg-spritemap" => "^3.0.0",
+                "svgo" => "^3.3.2"
                 // 'fontellizr' => 'voidgraphics/fontellizr',
             ],
             Arr::except($packages, [

--- a/src/stubs/vite.config.js
+++ b/src/stubs/vite.config.js
@@ -1,11 +1,17 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
+import VitePluginSvgSpritemap from '@spiriit/vite-plugin-svg-spritemap'
 
 export default defineConfig({
     plugins: [
         laravel({
             input: ['resources/sass/app.scss', 'resources/js/app.js'],
             refresh: true,
+        }),
+        VitePluginSvgSpritemap('./resources/icons/*.svg', {
+            output: {
+                filename: 'default.svg'
+            },
         }),
     ],
 });


### PR DESCRIPTION
Suite au passage à vite, on à plus de solution pour utiliser facilement une iconfont.
Du coup on en est arrivé à la conclusion que le mieux c'est d'utiliser une spritesheet svg.

Void à déjà [mis ça en place sur Hiker](https://github.com/hiker-dev/hiker/commit/ed5153cc272de6a25545457ecec8af780615ddf2) en utilisant [ce plugin vite](https://github.com/vbenjs/vite-plugin-svg-icons).

Sauf que ce plugin est pas archi top parce que il fonctionne que quand JS est actif, et il inclut toute la spritesheet à la fin du HTML.

Du coup j'ai fait un peu de recherche et j'ai trouvé [ce plugin](https://github.com/SpiriitLabs/vite-plugin-svg-spritemap) qui fonctionne quand JS est désactivé et qui crée un vrai fichier pour la spritesheet. (Et qui peut aussi générer plusieurs spritesheet et permet l'utilisation dans le css si jamais on à besoin).

Je l'ai déjà mis [en place sur Hiker Website](https://github.com/whitecube/hiker-website/blob/caf0928c2285e26096b6227c744db3741d88f5fa/vite.config.js#L3) et @voidgraphics m'a demandé de le mettre sur Laravel Preset.

J'en ai profité pour créer un composant `Icon` qu'on pourra mettre dans les composants réutilisables (Comme dans [IconButton](https://github.com/whitecube/laravel-preset/blob/bdcc332fb0be538a32a1ceb4f4fdaff8f7ce114e/components/icon-button/style.scss#L38-L41) qui fonctionne avec un iconfont pour le moment).

Il n'y a rien de particulier à savoir pour l'utiliser, juste qu'il faut faire `yarn build` pour générer la spritesheet. (Et du coup rebuild a chaque fois qu'on rajoute/modifier un icone mais ça c'est logique)

Le seul truc notable c'est que pour le moment [il y a un bug](https://github.com/SpiriitLabs/vite-plugin-svg-spritemap/issues/57) avec ce plugin ou le HMR ne fonctionne pas avec Laravel en mode dev. En attendant que ce bug soit fixé il y a un workaround en faisant du cache busting manuel et on pourra changer quand ce sera fix :))