### PR TITLE
Updated install process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "laravel/prompts": "^0.2.0",
+        "laravel/prompts": "^0.3.5",
         "laravel/ui": "^4.6"
     },
     "autoload": {

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -27,7 +27,8 @@ class Composer
 
         $packages = [
             'spatie/laravel-log-dumper',
-            'whitecube/laravel-sluggable'
+            'whitecube/laravel-sluggable',
+            'whitecube/laravel-timezones'
         ];
 
         $command->info(implode(', ', $packages));

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -15,23 +15,39 @@ class Composer
 
         static::$composer = app()->make(\Whitecube\LaravelPreset\Support\Composer::class);
 
-        static::installPackages($command);
+        static::installProductionPackages($command);
+        static::installDevelopmentPackages($command);
         static::copyStub();
     }
 
-    public static function installPackages()
+    public static function installProductionPackages()
     {
         $packages = [
-            'barryvdh/laravel-debugbar',
-            'pestphp/pest',
-            'pestphp/pest-plugin-laravel',
-            'laravel/pint',
             'spatie/laravel-log-dumper',
-            'spatie/laravel-ray',
             'whitecube/laravel-sluggable'
         ];
 
         static::$composer->run(['require', ...$packages]);
+    }
+
+    public static function installDevelopmentPackages()
+    {
+        // Install regular dev packages:
+        $packages = [
+            'barryvdh/laravel-debugbar',
+            'laravel/pint',
+            'spatie/laravel-ray',
+        ];
+
+        static::$composer->run(['require', ...$packages, '--dev']);
+
+        // Pest requires phpunit/phpunit to be removed
+        static::$composer->run(['remove', 'phpunit/phpunit']);
+        static::$composer->run(['remove', 'phpunit/phpunit', '--dev']);
+
+        // Install Pest
+        static::$composer->run(['require', 'pestphp/pest', '--dev', '--with-all-dependencies']);
+        static::$composer->run(['require', 'pestphp/pest-plugin-laravel', '--dev']);
     }
 
     public static function copyStub()

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -27,7 +27,7 @@ class Composer
             'whitecube/laravel-sluggable'
         ];
 
-        static::$composer->run(['require', ...$packages]);
+        static::$composer->run(['require', ...$packages, '--no-interaction']);
     }
 
     public static function installDevelopmentPackages()
@@ -39,15 +39,15 @@ class Composer
             'spatie/laravel-ray',
         ];
 
-        static::$composer->run(['require', ...$packages, '--dev']);
+        static::$composer->run(['require', ...$packages, '--dev', '--no-interaction']);
 
         // Pest requires phpunit/phpunit to be removed
-        static::$composer->run(['remove', 'phpunit/phpunit']);
-        static::$composer->run(['remove', 'phpunit/phpunit', '--dev']);
+        static::$composer->run(['remove', 'phpunit/phpunit', '--no-interaction']);
+        static::$composer->run(['remove', 'phpunit/phpunit', '--dev', '--no-interaction']);
 
         // Install Pest
-        static::$composer->run(['require', 'pestphp/pest', '--dev', '--with-all-dependencies']);
-        static::$composer->run(['require', 'pestphp/pest-plugin-laravel', '--dev']);
+        static::$composer->run(['require', 'pestphp/pest', '--dev', '--with-all-dependencies', '--no-interaction']);
+        static::$composer->run(['require', 'pestphp/pest-plugin-laravel', '--dev', '--no-interaction']);
     }
 
     public static function copyStub()

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -67,7 +67,7 @@ class Composer
         $command->info('Installing Testing Framework "PestPHP" and its Laravel plugin...');
 
         // Pest requires phpunit/phpunit to be removed.
-        // We'll removed both from the `require` and `require-dev` sections:
+        // We'll remove it both from the `require` and `require-dev` sections:
         static::$composer->run([
             'remove',
             'phpunit/phpunit',

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -17,15 +17,20 @@ class Composer
 
         static::installProductionPackages($command);
         static::installDevelopmentPackages($command);
+        static::installTestingPackages($command);
         static::copyStub();
     }
 
-    public static function installProductionPackages()
+    public static function installProductionPackages(UiCommand $command)
     {
+        $command->info('Installing the following "require" packages:');
+
         $packages = [
             'spatie/laravel-log-dumper',
             'whitecube/laravel-sluggable'
         ];
+
+        $command->info(implode(', ', $packages));
 
         static::$composer->run([
             'require',
@@ -35,14 +40,17 @@ class Composer
         ]);
     }
 
-    public static function installDevelopmentPackages()
+    public static function installDevelopmentPackages(UiCommand $command)
     {
-        // Install regular dev packages:
+        $command->info('Installing the following "require-dev" packages:');
+
         $packages = [
             'barryvdh/laravel-debugbar',
             'laravel/pint',
             'spatie/laravel-ray',
         ];
+
+        $command->info(implode(', ', $packages));
 
         static::$composer->run([
             'require',
@@ -51,6 +59,11 @@ class Composer
             '--sort-packages',
             '--no-interaction'
         ]);
+    }
+
+    public static function installTestingPackages(UiCommand $command)
+    {
+        $command->info('Installing Testing Framework "PestPHP" and its Laravel plugin...');
 
         // Pest requires phpunit/phpunit to be removed.
         // We'll removed both from the `require` and `require-dev` sections:

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -27,7 +27,12 @@ class Composer
             'whitecube/laravel-sluggable'
         ];
 
-        static::$composer->run(['require', ...$packages, '--no-interaction']);
+        static::$composer->run([
+            'require',
+            ...$packages,
+            '--sort-packages',
+            '--no-interaction'
+        ]);
     }
 
     public static function installDevelopmentPackages()
@@ -39,15 +44,44 @@ class Composer
             'spatie/laravel-ray',
         ];
 
-        static::$composer->run(['require', ...$packages, '--dev', '--no-interaction']);
+        static::$composer->run([
+            'require',
+            ...$packages,
+            '--dev',
+            '--sort-packages',
+            '--no-interaction'
+        ]);
 
-        // Pest requires phpunit/phpunit to be removed
-        static::$composer->run(['remove', 'phpunit/phpunit', '--no-interaction']);
-        static::$composer->run(['remove', 'phpunit/phpunit', '--dev', '--no-interaction']);
+        // Pest requires phpunit/phpunit to be removed.
+        // We'll removed both from the `require` and `require-dev` sections:
+        static::$composer->run([
+            'remove',
+            'phpunit/phpunit',
+            '--no-interaction'
+        ]);
+        static::$composer->run([
+            'remove',
+            'phpunit/phpunit',
+            '--dev',
+            '--no-interaction'
+        ]);
 
         // Install Pest
-        static::$composer->run(['require', 'pestphp/pest', '--dev', '--with-all-dependencies', '--no-interaction']);
-        static::$composer->run(['require', 'pestphp/pest-plugin-laravel', '--dev', '--no-interaction']);
+        static::$composer->run([
+            'require',
+            'pestphp/pest',
+            '--dev',
+            '--with-all-dependencies',
+            '--sort-packages',
+            '--no-interaction'
+        ]);
+        static::$composer->run([
+            'require',
+            'pestphp/pest-plugin-laravel',
+            '--dev',
+            '--sort-packages',
+            '--no-interaction'
+        ]);
     }
 
     public static function copyStub()

--- a/src/Pest.php
+++ b/src/Pest.php
@@ -8,7 +8,7 @@ class Pest
 {
     public static function install(UiCommand $command)
     {
-        $command->info('Preparing Pest...');
+        $command->info('Initializing Pest into the project...');
         
         shell_exec('PEST_NO_SUPPORT=true ./vendor/bin/pest --init');
     }

--- a/src/Pest.php
+++ b/src/Pest.php
@@ -10,6 +10,6 @@ class Pest
     {
         $command->info('Preparing Pest...');
         
-        shell_exec('./vendor/bin/pest --init');
+        shell_exec('PEST_NO_SUPPORT=true ./vendor/bin/pest --init');
     }
 }

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -2,7 +2,8 @@
 
 namespace Whitecube\LaravelPreset;
 
-use \Arr;
+use Arr;
+use File;
 use Laravel\Ui\UiCommand;
 use Laravel\Ui\Presets\Preset as LaravelPreset;
 
@@ -28,7 +29,7 @@ class Preset extends LaravelPreset
         shell_exec('git commit -m "Install laravel-preset"');
         static::updateScripts();
         static::addLintStaged();
-        \File::makeDirectory(base_path('.husky'));
+        static::makeHuskyDirectory($command);
         shell_exec('echo "yarn lint-staged" > .husky/pre-commit');
         shell_exec('yarn run postinstall');
         shell_exec('git add --all');
@@ -122,5 +123,19 @@ class Preset extends LaravelPreset
             base_path('package.json'),
             json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
         );
+    }
+
+    public static function makeHuskyDirectory(UiCommand $command)
+    {
+        $command->info('Creating .husky directory...');
+
+        if(File::exists(base_path('.husky'))) {
+            $command->info('.husky already exists, removing it for a fresh start...');
+            File::deleteDirectory(base_path('.husky'));
+        }
+
+        File::makeDirectory(base_path('.husky'));
+        
+        $command->info('Created a fresh .husky directory.');
     }
 }


### PR DESCRIPTION
This PR aims to improve the installation command on a few aspects which have been triggering a few issues lately.

**Improvements:**

- Composer: 
    - All "dev" packages will now be installed under the `require-dev` section of the project's `composer.json` file. Previously everything was added to the `require` section ;
    - All packages are installed with the `--no-interaction` flag, in order to prevent interruptions during the installation process ;
    - Added `whitecube/laravel-timezones` to the default `require` dependencies ;
    - Packages are now sorted in the `composer.json` file ;
    - `pestphp/pest` is now installed correctly as described in their docs (important when installing the preset on an existing project) ;
    - Better "info" output during the composer installation process.
- Pest: 
    - Pest's installation command does not interrupt the overall installation process anymore (it was requesting to give it a Github star) ;

**Fixes:**

- We now check if the `.husky` directory already exists before trying to create it. This was the case on one of my existing (but nearly fresh) projects. If it is already present we'll delete the existing directory and create a fresh one, in order to prevent further issues. 